### PR TITLE
Add Financial Disaster Preparedness Guide and Dependency Updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
-gem 'github-pages', '>= 227'
+gem 'github-pages'
 gem 'jekyll-sitemap'
 gem 'rspec'
-gem 'rack', '>= 3.0.0'
+gem 'rack'
 gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,4 +298,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.3.26
+   2.4.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.6)
+    activesupport (6.0.6.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -23,8 +23,8 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.23.6)
-    concurrent-ruby (1.1.10)
+    commonmarker (0.23.7)
+    concurrent-ruby (1.2.0)
     diff-lcs (1.5.0)
     dnsruby (1.61.9)
       simpleidn (~> 0.1)
@@ -35,7 +35,7 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.8.1)
-    faraday (2.7.2)
+    faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
@@ -212,7 +212,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.7.1)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     matrix (0.4.2)
@@ -223,11 +223,11 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.16.3)
-    nokogiri (1.13.10)
+    minitest (5.17.0)
+    nokogiri (1.14.0)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
+    nokogiri (1.14.0-x86_64-linux)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -236,13 +236,13 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (4.0.7)
     racc (1.6.2)
-    rack (3.0.2)
+    rack (3.0.4.1)
     rack-test (2.0.2)
       rack (>= 1.3)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    regexp_parser (2.6.1)
+    regexp_parser (2.6.2)
     rexml (3.2.5)
     rouge (3.26.0)
     rspec (3.12.0)
@@ -251,10 +251,10 @@ GEM
       rspec-mocks (~> 3.12.0)
     rspec-core (3.12.0)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.0)
+    rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -276,7 +276,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.10)
+    tzinfo (1.2.11)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
@@ -292,10 +292,10 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
-  github-pages (>= 227)
+  github-pages
   jekyll-sitemap
-  rack (>= 3.0.0)
+  rack
   rspec
 
 BUNDLED WITH
-   2.1.4
+   2.3.26

--- a/_includes/resources.md
+++ b/_includes/resources.md
@@ -9,3 +9,4 @@
 - [Hurricane Risk By County](https://www.arcgis.com/apps/Cascade/index.html?appid=8f6013fdba6445e9a8732ff6cab9cd1a)
 - Ward Law reached out to provide their [hurricane preparedness guide](https://www.855dolor55.com/en/hurricane-guide/) as a practical tool for steps to take when preparing for a hurricane
 - The Mesothelioma Center sent me their [Asbestos and Natural Disasters Guide](https://www.asbestos.com/asbestos/natural-disasters/) containing information about asbestos and the complexities it adds to hurricane prevention and response
+- Annuity.org shared [The Ultimate Guide to Disaster Preparedness For Your Finances](https://www.annuity.org/financial-literacy/disaster-preparedness/) with information about preparing for hurricane impacts and recovering from them


### PR DESCRIPTION
This pull request adds a reference to a financial disaster preparedness guide that Annuity.org reached out to provide. It also contains dependency updates.