### PR TITLE
Update NHC Tropical Weather Outlook and Separate Test and Production Builds

### DIFF
--- a/.github/workflows/build-and-deploy-test.yml
+++ b/.github/workflows/build-and-deploy-test.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Containerized Version of Website 
+name: Build and Publish Containerized Version of Website - Test Environment
   
 on:
   push: 
@@ -32,6 +32,7 @@ jobs:
          uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 
          with: 
            context: . 
+           file: ./Dockerfile.test
            push: true 
            tags: ${{ steps.meta.outputs.tags }} 
            labels: ${{ steps.meta.outputs.labels }} 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,38 @@
+ # Base Dockerfile components/structure 
+ # courtesy of https://www.deepanseeralan.com/tech/hosting-jekyll-site-in-gcp-cloud-run/. 
+  
+ # Use the latest Ruby Docker container and refer to it as "jekyll-website-build" 
+ # downstream: 
+ FROM ruby as jekyll-website-build 
+  
+ # Install Bundler for retrieving and loading dependencies downstream: 
+ RUN gem install bundler 
+  
+ # Set the working directory for subsequent 
+ # RUN, CMD, ADD, COPY and ENTRYPOINT commands: 
+ WORKDIR /build-directory 
+  
+ # Transfer the Gemfile to the build directory and 
+ # install gem dependencies: 
+ COPY Gemfile* /build-directory/ 
+ RUN bundle install 
+  
+ # Take the root contents (with the repository files necessary) 
+ # to generate the website and copy them to the build-directory: 
+ COPY . . 
+  
+ # Set environment build variables and create the static website content: 
+ ENV JEKYLL_ENV=test 
+ RUN bundle exec jekyll build 
+  
+ # An nginx container is created to serve the website: 
+ FROM nginx 
+  
+ # The website files now reside in /build-directory/_site in the 
+ # jekyll-website-build container. They are transferred to 
+ # /usr/share/nginx/html: 
+ COPY --from=jekyll-website-build  /build-directory/_site /usr/share/nginx/html 
+  
+ # Finally, the the nginx.conf file is transferred to 
+ # /etc/nginx.conf.d/default.conf: 
+ COPY /nginx.conf /etc/nginx/conf.d/default.conf

--- a/additional-resources.md
+++ b/additional-resources.md
@@ -18,7 +18,7 @@ In addition to the outlook above, this [resource from Colorado State University]
 Curious about whether there are currently any active storms in the Gulf of Mexico or Atlantic? See the graphic below from the National Hurricane Center, and click it for additional information.
 
 <br>
-<a href="https://www.nhc.noaa.gov/text/MIATWDAT.shtml"> <img src="https://www.nhc.noaa.gov/xgtwo/two_atl_5d0.png" alt="National Hurricane Center Tropical Weather Outlook" class="preview-image"/></a>
+<a href="https://www.nhc.noaa.gov/text/MIATWDAT.shtml"> <img src="https://www.nhc.noaa.gov/xgtwo/two_atl_7d0.png" alt="National Hurricane Center Tropical Weather Outlook" class="preview-image"/></a>
 
 {% include resources.md map_location_statement="While the maps on this website are useful for helping visualize what sea level rise looks like in your area of interest, there are many other great resources available." %}
 

--- a/index.md
+++ b/index.md
@@ -47,7 +47,7 @@ Additional references and resources to learn more about sea levels and how they 
 Curious about whether there are currently any active storms in the Gulf of Mexico or Atlantic? See the graphic below from the National Hurricane Center, and click it for additional information.
 
 <br>
-<a href="https://www.nhc.noaa.gov/text/MIATWDAT.shtml"> <img src="https://www.nhc.noaa.gov/xgtwo/two_atl_5d0.png" alt="National Hurricane Center Tropical Weather Outlook" class="preview-image"/></a>
+<a href="https://www.nhc.noaa.gov/text/MIATWDAT.shtml"> <img src="https://www.nhc.noaa.gov/xgtwo/two_atl_7d0.png" alt="National Hurricane Center Tropical Weather Outlook" class="preview-image"/></a>
 
 ## Suggestions and Feedback
 


### PR DESCRIPTION
This pull request updates the graphical NHC Tropical Weather Outlook Following the agency's change to the use of 7 day forecasts instead of 5 days. A spare Docker image is now created for the test environment along with a dedicated build and deployment workflow.