### PR TITLE
Revise Environment Build Status Badges and Add Notification to Test Environment Pages

### DIFF
--- a/.github/workflows/build-and-deploy-production.yml
+++ b/.github/workflows/build-and-deploy-production.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Containerized Version of Website
+name: Build and Publish Containerized Version of Website - Production
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ There are two environments associated with this project. The first is the produc
 The badges below show the status of the most recent continuous integration pipeline runs (used to ensure source code changes do not induce website deployment failures and pass a series of RSpec tests) and test environment build:
 
 [![Continuous Integration Testing Pipeline](https://github.com/PaulRosenthal/Coastal-Florida-Climate-Changes/actions/workflows/CI-Pipeline.yml/badge.svg)](https://github.com/PaulRosenthal/Coastal-Florida-Climate-Changes/actions/workflows/CI-Pipeline.yml)
-[![Netlify Status](https://api.netlify.com/api/v1/badges/86f3f288-26f7-492b-96a2-fe86728b72c0/deploy-status)](https://app.netlify.com/sites/coastal-florida-climate-changes/deploys)
+[![Build and Deploy Pipeline - Test](https://github.com/PaulRosenthal/Coastal-Florida-Climate-Changes/actions/workflows/build-and-deploy-test.yml/badge.svg)](https://github.com/PaulRosenthal/Coastal-Florida-Climate-Changes/actions/workflows/build-and-deploy-test.yml)
+[![Build and Deploy Pipeline - Production](https://github.com/PaulRosenthal/Coastal-Florida-Climate-Changes/actions/workflows/build-and-deploy-production.yml/badge.svg)](https://github.com/PaulRosenthal/Coastal-Florida-Climate-Changes/actions/workflows/build-and-deploy-production.yml)
+
 
 ## Feedback or Contributions
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,6 +38,10 @@
   </head>
   <body>
 
+{% if jekyll.environment == "test" %}
+<b>This is the test environment for the Sea Florida Change website. The production version is located <a href="https://SeaFLChange.org/">here</a>.</b> 
+{% endif %}
+
     <header class="page-header" role="banner">
       <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
       <h2 class="project-tagline">{{ page.tagline | default: page.description | default: site.description }}</h2>


### PR DESCRIPTION
This pull request revises the environment build status badges in the repository's README.md file. It also adds a message displayed on test environment pages informing users they are not on the production website.