### PR TITLE
Resolve Bug in Navigation Dropdown Sections

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -81,7 +81,7 @@
 
   @include small {
     width: 200%;
-    transform: translate(-40%, -3%);
+    z-index: 1;
   }
 }
 


### PR DESCRIPTION
This pull request resolves a bug for users on mobile/small devices. Previously, the navigation buttons for dropdown sections could be pushed too far to the left and off of the user's screen. Additionally, these buttons sometimes appeared behind other elements.